### PR TITLE
Use released 2.2.2 ONOS image

### DIFF
--- a/start-onos.sh
+++ b/start-onos.sh
@@ -3,4 +3,4 @@
 docker run -it --rm \
   -e ONOS_APPS=gui2,drivers.bmv2,pipelines.basic,lldpprovider,hostprovider,fwd \
   -p 8101:8101 -p 8181:8181 \
-  onosproject/onos:2.2.x
+  onosproject/onos:2.2.2


### PR DESCRIPTION
Instead of 2.2.x, which seems to be a test build from 8 months ago:
https://hub.docker.com/layers/onosproject/onos/2.2.x/images/sha256-af3d4d65002482b75af15878ee394663be53abd023b84beb2d501fb4673db80d?context=explore